### PR TITLE
Update socket-timeout

### DIFF
--- a/docker/webapp/web-app.ini
+++ b/docker/webapp/web-app.ini
@@ -4,6 +4,7 @@ master = true
 plugins = python
 
 socket = 0.0.0.0:5000
+socket-timeout = 90
 
 uid = www-data
 gid = www-data


### PR DESCRIPTION
This change increases the default socket timeout from 60 seconds to 90 seconds to better handle large file uploads.